### PR TITLE
Fix deprecation warnings (rust 1.51)

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -108,7 +108,7 @@ fn print_t_test(t_test: &TTest, s1: &Summary, s2: &Summary) {
     println!("{l:>w$} = {v}", w = width, l = "DF", v = t_test.df);
 }
 
-fn summarize_file(path: &str, lax_parsing: bool) -> Result<Summary, Box<error::Error>> {
+fn summarize_file(path: &str, lax_parsing: bool) -> Result<Summary, Box<dyn error::Error>> {
     let f = File::open(path).or_else(|e| {
         log::error(&format!("Could not open file: {:?}", path));
         Err(e)
@@ -120,7 +120,7 @@ fn summarize_file(path: &str, lax_parsing: bool) -> Result<Summary, Box<error::E
     Ok(Summary::new(&data)?)
 }
 
-fn read_data<R>(reader: R, lax_parsing: bool) -> Result<Vec<f64>, Box<error::Error>>
+fn read_data<R>(reader: R, lax_parsing: bool) -> Result<Vec<f64>, Box<dyn error::Error>>
     where R: BufRead {
     let mut data: Vec<f64> = vec![];
 
@@ -140,7 +140,7 @@ fn read_data<R>(reader: R, lax_parsing: bool) -> Result<Vec<f64>, Box<error::Err
     Ok(data)
 }
 
-fn summarize_stdin(lax_parsing: bool) -> Result<Summary, Box<error::Error>> {
+fn summarize_stdin(lax_parsing: bool) -> Result<Summary, Box<dyn error::Error>> {
     let stdin = io::stdin();
     let data = read_data(stdin.lock(), lax_parsing)?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,17 +11,17 @@ pub enum Error {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        write!(f, "{}", std::error::Error::description(self))
+        write!(
+            f,
+            "{}",
+            match *self {
+                Error::BadSample => "All sample data must be finite",
+                Error::Diverged => "Numeric evaluation diverged",
+                Error::EmptySample => "Sample data set cannot be empty",
+                Error::Undefined => "Function undefined for argument",
+            }
+        )
     }
 }
 
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::BadSample => "All sample data must be finite",
-            Error::Diverged => "Numeric evaluation diverged",
-            Error::EmptySample => "Sample data set cannot be empty",
-            Error::Undefined => "Function undefined for argument",
-        }
-    }
-}
+impl std::error::Error for Error {}

--- a/tests/support/kat.rs
+++ b/tests/support/kat.rs
@@ -157,10 +157,8 @@ macro_rules! assert_appx_eq {
     ($name:expr, $tolerance:expr, $known:expr, $actual:expr) => {
         let d = ($known - $actual).abs();
 
-        let err = format!("{}: {} and {} differ by {} > {}",
-                          $name, $known, $actual, d, $tolerance);
-
-        assert!(d < $tolerance, err);
+        assert!(d < $tolerance, "{}: {} and {} differ by {} > {}",
+                $name, $known, $actual, d, $tolerance);
     };
 }
 


### PR DESCRIPTION
For Error, drop the deprecated description() method and move the logic
into the Display impl.

In bin.rs, use explicit 'dyn' annotation for Boxes of traits.  This is
functionally identical, but the older syntax is deprecated.

In the KAT support logic, the format string of an assert!() must be a
string literal in Rust 2021.  As the variable we were using for the
format string was itself a formatted string, we can just simplify by
doing the formatting in assert!() itself.